### PR TITLE
Remove nose and ipdb from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,4 @@ setup(name='sure',
     author_email='gabriel@nacaolivre.org',
     url='http://github.com/gabrielfalcao/sure',
     packages=get_packages(),
-    install_requires=[
-          "nose",
-          "ipdb",
-    ],
 )


### PR DESCRIPTION
The library doesn't actually use them, so it just slows down installation. 
