### PR TITLE
Added `equal_to` as an alias for `equal`.

### DIFF
--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -606,6 +606,7 @@ class AssertionBuilder(object):
 
     eql = equal
     equals = equal
+    equal_to = equal
 
     @assertionmethod
     def an(self, klass):


### PR DESCRIPTION
So now you can write `(2).should.be.equal_to(2)`. This reads better than `(2).should.be.equal(2)`
