### PR TITLE
Added _IdentityAssertion, to be used by 'be'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 dist/
 sure.egg-info/
 .tox
+*.sublime-project
+*.sublime-workspace

--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -409,6 +409,20 @@ NEGATIVES = [
     'shouldnot',
 ]
 
+class _IdentityAssertion(object):
+    def __init__(self, assertion_builder):
+        self._ab = assertion_builder
+
+    def __call__(self, other):
+        if self._ab.negative:
+            assert self._ab.obj is not other, "{0} should not be the same object as {1}, but it is".format(self._ab.obj, other)
+            return True
+        assert self._ab.obj is other, "{0} should be the same object as {1}, but it is not".format(self._ab.obj, other)
+        return True
+
+    def __getattr__(self, name):
+        return getattr(self._ab, name)
+
 
 class AssertionBuilder(object):
     def __init__(self, name=None, negative=False, obj=None):
@@ -452,19 +466,15 @@ class AssertionBuilder(object):
 
     @assertionproperty
     def be(self):
-        return self
+        return _IdentityAssertion(self)
 
-    @assertionproperty
-    def being(self):
-        return self
-
-    @assertionproperty
-    def not_being(self):
-        return self.should_not
+    being = be
 
     @assertionproperty
     def not_be(self):
-        return self.should_not
+        return _IdentityAssertion(self.should_not)
+
+    not_being = not_be
 
     @assertionproperty
     def not_have(self):
@@ -524,7 +534,7 @@ class AssertionBuilder(object):
             assert length > 0, (
                 u"expected `{0}` to not be empty".format(representation))
         else:
-            assert length is 0, (
+            assert length == 0, (
                 u"expected `{0}` to be empty but it has {1} items".format(representation, length))
 
         return True

--- a/tests/test_assertion_builder.py
+++ b/tests/test_assertion_builder.py
@@ -294,6 +294,21 @@ def test_lower_than_or_equal_to():
         "expected `1` to not be lower than or equal to `2`")
 
 
+def test_be():
+    (u"this(X).should.be(X) when X is a reference to the same object")
+
+    d1 = {}
+    d2 = d1
+    d3 = {}
+
+    assert isinstance(this(d2).should.be(d1), bool)
+    assert this(d2).should.be(d1)
+    assert this(d3).should_not.be(d1)
+
+    (this(d2).should_not.be).when.called_with(d1).should.throw(AssertionError)
+    (this(d3).should.be).when.called_with(d1).should.throw(AssertionError)
+
+
 def test_have_property():
     (u"this(instance).should.have.property(property_name)")
 


### PR DESCRIPTION
You can now write `x.should.be(y)` when you want to test for object identity. All the other uses of `be` still work.

Closes #34
