### PR TITLE
Fix #48.

### DIFF
--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -435,10 +435,13 @@ class AssertionBuilder(object):
         self._that = AssertionHelper(self.obj)
 
     def __call__(self, obj):
+
         self.obj = obj
 
         if isinstance(obj, self.__class__):
             self.obj = obj.obj
+            self._callable_args = obj._callable_args
+            self._callable_kw = obj._callable_kw
 
         self._that = AssertionHelper(self.obj)
         return self
@@ -754,7 +757,6 @@ class AssertionBuilder(object):
 
         return self._that.len_is(num)
 
-    @assertionmethod
     def called_with(self, *args, **kw):
         self._callable_args = args
         self._callable_kw = kw

--- a/tests/test_issue_48.py
+++ b/tests/test_issue_48.py
@@ -1,0 +1,7 @@
+import sure
+
+def raise_err(foobar):
+    raise ValueError()
+
+def test_issue_48():
+    raise_err.when.called_with('asdf').should.throw(ValueError)


### PR DESCRIPTION
AssertionBuilder.__call__ wasn't pushing through the
_callable_args and _callable_kw attributes, so they
weren't percolated through the assertion chain.

I also removed the assertion_method decorator from called_with, because it was causing the function to be evaluated too early (and its not an assertion in that sense).