### PR TITLE
Handle setup.py dependencies separate to requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@
 
 import ast
 import os
-import re
 from setuptools import setup, find_packages
 
 
@@ -42,39 +41,11 @@ def read_version():
     return finder.version
 
 
-def parse_requirements(path):
-    """Rudimentary parser for the `requirements.txt` file
-
-    We just want to separate regular packages from links to pass them to the
-    `install_requires` and `dependency_links` params of the `setup()`
-    function properly.
-    """
-    try:
-        requirements = map(str.strip, local_file(path).splitlines())
-    except IOError:
-        raise RuntimeError("Couldn't find the `requirements.txt' file :(")
-
-    links = []
-    pkgs = []
-    for req in requirements:
-        if not req:
-            continue
-        if 'http:' in req or 'https:' in req:
-            links.append(req)
-            name, version = re.findall("\#egg=([^\-]+)-(.+$)", req)[0]
-            pkgs.append('{0}=={1}'.format(name, version))
-        else:
-            pkgs.append(req)
-
-    return pkgs, links
-
-
 local_file = lambda *f: \
     open(os.path.join(os.path.dirname(__file__), *f)).read()
 
 
-install_requires, dependency_links = \
-    parse_requirements('requirements.txt')
+tests_require = ['nose']
 
 
 if __name__ == '__main__':
@@ -87,6 +58,6 @@ if __name__ == '__main__':
           include_package_data=True,
           url='http://github.com/gabrielfalcao/sure',
           packages=find_packages(exclude=['*tests*']),
-          install_requires=install_requires,
-          dependency_links=dependency_links,
+          tests_require=tests_require,
+          test_suite='nose.collector',
     )


### PR DESCRIPTION
The usage of these two files is very different and setup.py should not
have the strict version requirements that requirements.txt does
otherwise we create dependency problems for packagers and people using
the library.

Also changes the existing dependencies from install requirements to test
requirements and registered nose as the test handler in setup.py.

Fixes Issue #56
