### PR TITLE
Do not use the "u" prefix when 'unicode_literals' is imported.

### DIFF
--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -89,7 +89,7 @@ class VariablesBag(dict):
 
 
 class CallBack(object):
-    context_error = u"the function %s defined at %s line %d, is being "\
+    context_error = "the function %s defined at %s line %d, is being "\
         "decorated by either @that_with_context or @scenario, so it should " \
         "take at least 1 parameter, which is the test context"
 
@@ -178,9 +178,9 @@ def within(**units):
             except TypeError as e:
                 if PY3:
                     # PY3 has different error message
-                    fmt = u'{0}() takes 0 positional arguments but 1 was given'
+                    fmt = '{0}() takes 0 positional arguments but 1 was given'
                 else:
-                    fmt = u'{0}() takes no arguments'
+                    fmt = '{0}() takes no arguments'
                 err = text_type(e)
                 if fmt.format(func.__name__) in err:
                     func(*args, **kw)
@@ -225,10 +225,10 @@ UNITS = {
     ),
 }
 
-milisecond = miliseconds = u'miliseconds'
-microsecond = microseconds = u'microseconds'
-second = seconds = u'seconds'
-minute = minutes = u'minutes'
+milisecond = miliseconds = 'miliseconds'
+microsecond = microseconds = 'microseconds'
+second = seconds = 'seconds'
+minute = minutes = 'minutes'
 
 
 def word_to_number(word):
@@ -299,12 +299,12 @@ def action_for(context, provides=None, depends_on=None):
             'into the context, but it did not. Please double check its ' \
             'implementation' % (func.__name__, attr)
 
-    dependency_error_lonely = u'the action "%s" defined at %s:%d ' \
+    dependency_error_lonely = 'the action "%s" defined at %s:%d ' \
         'depends on the attribute "%s" to be available in the' \
         ' context. It turns out that there are no actions providing ' \
         'that. Please double-check the implementation'
 
-    dependency_error_hints = u'the action "%s" defined at %s:%d ' \
+    dependency_error_hints = 'the action "%s" defined at %s:%d ' \
         'depends on the attribute "%s" to be available in the context.'\
         ' You need to call one of the following actions beforehand:\n'
 
@@ -538,20 +538,20 @@ class AssertionBuilder(object):
         length = len(self.obj)
         if self.negative:
             assert length > 0, (
-                u"expected `{0}` to not be empty".format(representation))
+                "expected `{0}` to not be empty".format(representation))
         else:
             assert length == 0, (
-                u"expected `{0}` to be empty but it has {1} items".format(representation, length))
+                "expected `{0}` to be empty but it has {1} items".format(representation, length))
 
         return True
 
     @assertionproperty
     def ok(self):
         if self.negative:
-            msg = u'expected `{0}` to be falsy'.format(self.obj)
+            msg = 'expected `{0}` to be falsy'.format(self.obj)
             assert not bool(self.obj), msg
         else:
-            msg = u'expected `{0}` to be truthy'.format(self.obj)
+            msg = 'expected `{0}` to be truthy'.format(self.obj)
             assert bool(self.obj), msg
 
         return True
@@ -562,10 +562,10 @@ class AssertionBuilder(object):
     @assertionproperty
     def falsy(self):
         if self.negative:
-            msg = u'expected `{0}` to be truthy'.format(self.obj)
+            msg = 'expected `{0}` to be truthy'.format(self.obj)
             assert bool(self.obj), msg
         else:
-            msg = u'expected `{0}` to be falsy'.format(self.obj)
+            msg = 'expected `{0}` to be falsy'.format(self.obj)
             assert not bool(self.obj), msg
 
         return True
@@ -644,9 +644,9 @@ class AssertionBuilder(object):
                     first = '_abcoll'
             else:
                 if sys.version_info <= (3, 0, 0):
-                    first = u'__builtin__'
+                    first = '__builtin__'
                 else:
-                    first = u'builtins'
+                    first = 'builtins'
                 items = [klass]
 
             klass = reduce(getattr, items, __import__(first))
@@ -669,13 +669,13 @@ class AssertionBuilder(object):
     @assertionmethod
     def greater_than(self, dest):
         if self.negative:
-            msg = u"expected `{0}` to not be greater than `{1}`".format(
+            msg = "expected `{0}` to not be greater than `{1}`".format(
                 self.obj, dest)
 
             assert not self.obj > dest, msg
 
         else:
-            msg = u"expected `{0}` to be greater than `{1}`".format(
+            msg = "expected `{0}` to be greater than `{1}`".format(
                 self.obj, dest)
             assert self.obj > dest, msg
 
@@ -684,13 +684,13 @@ class AssertionBuilder(object):
     @assertionmethod
     def greater_than_or_equal_to(self, dest):
         if self.negative:
-            msg = u"expected `{0}` to not be greater than or equal to `{1}`".format(
+            msg = "expected `{0}` to not be greater than or equal to `{1}`".format(
                 self.obj, dest)
 
             assert not self.obj >= dest, msg
 
         else:
-            msg = u"expected `{0}` to be greater than or equal to `{1}`".format(
+            msg = "expected `{0}` to be greater than or equal to `{1}`".format(
                 self.obj, dest)
             assert self.obj >= dest, msg
 
@@ -699,13 +699,13 @@ class AssertionBuilder(object):
     @assertionmethod
     def lower_than(self, dest):
         if self.negative:
-            msg = u"expected `{0}` to not be lower than `{1}`".format(
+            msg = "expected `{0}` to not be lower than `{1}`".format(
                 self.obj, dest)
 
             assert not self.obj < dest, msg
 
         else:
-            msg = u"expected `{0}` to be lower than `{1}`".format(
+            msg = "expected `{0}` to be lower than `{1}`".format(
                 self.obj, dest)
             assert self.obj < dest, msg
 
@@ -714,13 +714,13 @@ class AssertionBuilder(object):
     @assertionmethod
     def lower_than_or_equal_to(self, dest):
         if self.negative:
-            msg = u"expected `{0}` to not be lower than or equal to `{1}`".format(
+            msg = "expected `{0}` to not be lower than or equal to `{1}`".format(
                 self.obj, dest)
 
             assert not self.obj <= dest, msg
 
         else:
-            msg = u"expected `{0}` to be lower than or equal to `{1}`".format(
+            msg = "expected `{0}` to be lower than or equal to `{1}`".format(
                 self.obj, dest)
             assert self.obj <= dest, msg
 
@@ -729,10 +729,10 @@ class AssertionBuilder(object):
     @assertionmethod
     def below(self, num):
         if self.negative:
-            msg = u"{0} should not be below {1}".format(self.obj, num)
+            msg = "{0} should not be below {1}".format(self.obj, num)
             assert not self.obj < num, msg
         else:
-            msg = u"{0} should be below {1}".format(self.obj, num)
+            msg = "{0} should be below {1}".format(self.obj, num)
             assert self.obj < num, msg
 
         return True
@@ -740,10 +740,10 @@ class AssertionBuilder(object):
     @assertionmethod
     def above(self, num):
         if self.negative:
-            msg = u"{0} should not be above {1}".format(self.obj, num)
+            msg = "{0} should not be above {1}".format(self.obj, num)
             assert not self.obj > num, msg
         else:
-            msg = u"{0} should be above {1}".format(self.obj, num)
+            msg = "{0} should be above {1}".format(self.obj, num)
             assert self.obj > num, msg
         return True
 
@@ -769,7 +769,7 @@ class AssertionBuilder(object):
                      and_kwargs=self._callable_kw)
 
         if self.negative:
-            msg = (u"{0} called with args {1} and kwargs {2} should "
+            msg = ("{0} called with args {1} and kwargs {2} should "
                    "not raise {3} but raised {4}")
 
             exc = args and args[0] or Exception

--- a/sure/core.py
+++ b/sure/core.py
@@ -129,7 +129,7 @@ class DeepComparison(object):
         if X == Y:
             return True
         else:
-            m = u'X%s != Y%s' % (red(c.current_X_keys), green(c.current_Y_keys))
+            m = 'X%s != Y%s' % (red(c.current_X_keys), green(c.current_Y_keys))
             return DeepExplanation(m)
 
     def compare_dicts(self, X, Y):
@@ -141,14 +141,14 @@ class DeepComparison(object):
         diff_x = list(set(x_keys).difference(set(y_keys)))
         diff_y = list(set(y_keys).difference(set(x_keys)))
         if diff_x:
-            msg = u"X%s has the key %%r whereas Y%s does not" % (
+            msg = "X%s has the key %%r whereas Y%s does not" % (
                 red(c.current_X_keys),
                 green(c.current_Y_keys),
             ) % diff_x[0]
             return DeepExplanation(msg)
 
         elif diff_y:
-            msg = u"X%s does not have the key %%r whereas Y%s has it" % (
+            msg = "X%s does not have the key %%r whereas Y%s has it" % (
                 red(c.current_X_keys),
                 green(c.current_Y_keys),
             ) % diff_y[0]
@@ -201,10 +201,10 @@ class DeepComparison(object):
     def compare_iterables(self, X, Y):
         len_X, len_Y = map(len, (X, Y))
         if len_X > len_Y:
-            msg = u"X has %d items whereas Y has only %d" % (len_X, len_Y)
+            msg = "X has %d items whereas Y has only %d" % (len_X, len_Y)
             return DeepExplanation(msg)
         elif len_X < len_Y:
-            msg = u"Y has %d items whereas X has only %d" % (len_Y, len_X)
+            msg = "Y has %d items whereas X has only %d" % (len_Y, len_X)
             return DeepExplanation(msg)
         elif X == Y:
             return True
@@ -226,13 +226,13 @@ class DeepComparison(object):
             if X == Y:
                 return True
             c = self.get_context()
-            m = u"X%s is %%r whereas Y%s is %%r"
+            m = "X%s is %%r whereas Y%s is %%r"
             msg = m % (red(c.current_X_keys), green(c.current_Y_keys)) % (X, Y)
             return DeepExplanation(msg)
 
         elif type(X) is not type(Y):  # different types
             xname, yname = map(lambda _: type(_).__name__, (X, Y))
-            msg = u'X%s is a %%s and Y%s is a %%s instead' % (
+            msg = 'X%s is a %%s and Y%s is a %%s instead' % (
                 red(c.current_X_keys),
                 green(c.current_Y_keys),
             ) % (xname, yname)

--- a/sure/old.py
+++ b/sure/old.py
@@ -177,7 +177,7 @@ class AssertionHelper(object):
 
     def equals(self, dst):
         if self._attribute and is_iterable(self._src):
-            msg = u'%r[%d].%s should be %r, but is %r'
+            msg = '%r[%d].%s should be %r, but is %r'
 
             for index, item in enumerate(self._src):
                 if self._range:
@@ -199,12 +199,12 @@ class AssertionHelper(object):
         old_dst = pformat(dst)
         self._src = re.sub(r'\s', '', self._src).lower()
         dst = re.sub(r'\s', '', dst).lower()
-        error = u'%s does not look like %s' % (old_src, old_dst)
+        error = '%s does not look like %s' % (old_src, old_dst)
         assert self._src == dst, error
         return self._src == dst
 
     def every_one_is(self, dst):
-        msg = u'all members of %r should be %r, but the %dth is %r'
+        msg = 'all members of %r should be %r, but the %dth is %r'
         for index, item in enumerate(self._src):
             if self._range:
                 if index < self._range[0] or index > self._range[1]:
@@ -248,7 +248,7 @@ class AssertionHelper(object):
         length = len(self._src)
 
         if length <= that:
-            error = u'the length of the %s should be greater then %d, but is %d' % (
+            error = 'the length of the %s should be greater then %d, but is %d' % (
                 type(self._src).__name__,
                 that,
                 length,
@@ -263,7 +263,7 @@ class AssertionHelper(object):
         length = len(self._src)
 
         if length < that:
-            error = u'the length of %r should be greater then or equals %d, but is %d' % (
+            error = 'the length of %r should be greater then or equals %d, but is %d' % (
                 self._src,
                 that,
                 length,
@@ -281,7 +281,7 @@ class AssertionHelper(object):
         length = len(self._src)
 
         if length >= that:
-            error = u'the length of %r should be lower then %r, but is %d' % (
+            error = 'the length of %r should be lower then %r, but is %d' % (
                 self._src,
                 original_that,
                 length,
@@ -294,7 +294,7 @@ class AssertionHelper(object):
         that = self._get_that(that)
 
         length = len(self._src)
-        error = u'the length of %r should be lower then or equals %d, but is %d'
+        error = 'the length of %r should be lower then or equals %d, but is %d'
 
         if length > that:
             msg = error % (
@@ -311,7 +311,7 @@ class AssertionHelper(object):
         length = len(self._src)
 
         if length != that:
-            error = u'the length of %r should be %d, but is %d' % (
+            error = 'the length of %r should be %d, but is %d' % (
                 self._src,
                 that,
                 length,
@@ -325,7 +325,7 @@ class AssertionHelper(object):
         length = len(self._src)
 
         if length == that:
-            error = u'the length of %r should not be %d' % (
+            error = 'the length of %r should not be %d' % (
                 self._src,
                 that,
             )
@@ -345,7 +345,7 @@ class AssertionHelper(object):
         return self
 
     def matches(self, items):
-        msg = u'%r[%d].%s should be %r, but is %r'
+        msg = '%r[%d].%s should be %r, but is %r'
         get_eval = lambda item: eval(
             "%s.%s" % ('current', self._eval), {}, {'current': item},
         )

--- a/tests/test_assertion_builder.py
+++ b/tests/test_assertion_builder.py
@@ -22,7 +22,7 @@ from sure.six import PY3, compat_repr
 
 
 def test_assertion_builder_synonyms():
-    (u"this, it, these and those are all synonyms")
+    ("this, it, these and those are all synonyms")
 
     assert isinstance(it, AssertionBuilder)
     assert isinstance(this, AssertionBuilder)
@@ -31,7 +31,7 @@ def test_assertion_builder_synonyms():
 
 
 def test_4_equal_2p2():
-    (u"this(4).should.equal(2 + 2)")
+    ("this(4).should.equal(2 + 2)")
 
     time = datetime.now()
 
@@ -53,7 +53,7 @@ def test_4_equal_2p2():
 
 
 def test_2_within_0a2():
-    (u"this(1).should.be.within(0, 2)")
+    ("this(1).should.be.within(0, 2)")
 
     assert this(1).should.be.within(0, 2)
     assert this(4).should_not.be.within(0, 2)
@@ -72,7 +72,7 @@ def test_2_within_0a2():
 
 
 def test_true_be_ok():
-    (u"this(True).should.be.ok")
+    ("this(True).should.be.ok")
 
     assert this(True).should.be.ok
     assert this(False).should_not.be.ok
@@ -91,7 +91,7 @@ def test_true_be_ok():
 
 
 def test_false_be_falsy():
-    (u"this(False).should.be.false")
+    ("this(False).should.be.false")
 
     assert this(False).should.be.falsy
     assert this(True).should_not.be.falsy
@@ -110,7 +110,7 @@ def test_false_be_falsy():
 
 
 def test_none():
-    (u"this(None).should.be.none")
+    ("this(None).should.be.none")
 
     assert this(None).should.be.none
     assert this(not None).should_not.be.none
@@ -129,7 +129,7 @@ def test_none():
 
 
 def test_should_be_a():
-    (u"this(None).should.be.none")
+    ("this(None).should.be.none")
 
     assert this(1).should.be.an(int)
     assert this([]).should.be.a('collections.Iterable')
@@ -149,7 +149,7 @@ def test_should_be_a():
 
 
 def test_should_be_callable():
-    (u"this(function).should.be.callable")
+    ("this(function).should.be.callable")
 
     assert this(lambda: None).should.be.callable
     assert this("aa").should_not.be.callable
@@ -170,7 +170,7 @@ def test_should_be_callable():
 
 
 def test_iterable_should_be_empty():
-    (u"this(iterable).should.be.empty")
+    ("this(iterable).should.be.empty")
 
     assert this([]).should.be.empty
     assert this([1, 2, 3]).should_not.be.empty
@@ -190,7 +190,7 @@ def test_iterable_should_be_empty():
 
 
 def test_iterable_should_have_length_of():
-    (u"this(iterable).should.have.length_of(N)")
+    ("this(iterable).should.have.length_of(N)")
 
     assert this({'foo': 'bar', 'a': 'b'}).should.have.length_of(2)
     assert this([1, 2, 3]).should_not.have.length_of(4)
@@ -211,7 +211,7 @@ def test_iterable_should_have_length_of():
 
 
 def test_greater_than():
-    (u"this(X).should.be.greater_than(Y)")
+    ("this(X).should.be.greater_than(Y)")
 
     assert this(5).should.be.greater_than(4)
     assert this(1).should_not.be.greater_than(2)
@@ -232,7 +232,7 @@ def test_greater_than():
 
 
 def test_greater_than_or_equal_to():
-    (u"this(X).should.be.greater_than_or_equal_to(Y)")
+    ("this(X).should.be.greater_than_or_equal_to(Y)")
 
     assert this(4).should.be.greater_than_or_equal_to(4)
     assert this(1).should_not.be.greater_than_or_equal_to(2)
@@ -253,7 +253,7 @@ def test_greater_than_or_equal_to():
 
 
 def test_lower_than():
-    (u"this(X).should.be.lower_than(Y)")
+    ("this(X).should.be.lower_than(Y)")
 
     assert this(4).should.be.lower_than(5)
     assert this(2).should_not.be.lower_than(1)
@@ -274,7 +274,7 @@ def test_lower_than():
 
 
 def test_lower_than_or_equal_to():
-    (u"this(X).should.be.lower_than_or_equal_to(Y)")
+    ("this(X).should.be.lower_than_or_equal_to(Y)")
 
     assert this(5).should.be.lower_than_or_equal_to(5)
     assert this(2).should_not.be.lower_than_or_equal_to(1)
@@ -295,7 +295,7 @@ def test_lower_than_or_equal_to():
 
 
 def test_be():
-    (u"this(X).should.be(X) when X is a reference to the same object")
+    ("this(X).should.be(X) when X is a reference to the same object")
 
     d1 = {}
     d2 = d1
@@ -322,7 +322,7 @@ def test_be():
 
 
 def test_have_property():
-    (u"this(instance).should.have.property(property_name)")
+    ("this(instance).should.have.property(property_name)")
 
     class Person(object):
         name = "John Doe"
@@ -351,7 +351,7 @@ def test_have_property():
 
 
 def test_have_property_with_value():
-    (u"this(instance).should.have.property(property_name).being or "
+    ("this(instance).should.have.property(property_name).being or "
      ".with_value should allow chain up")
 
     class Person(object):
@@ -383,7 +383,7 @@ def test_have_property_with_value():
 
 
 def test_have_key():
-    (u"this(dictionary).should.have.key(key_name)")
+    ("this(dictionary).should.have.key(key_name)")
 
     jay = {'name': "John Doe"}
 
@@ -407,7 +407,7 @@ def test_have_key():
 
 
 def test_have_key_with_value():
-    (u"this(dictionary).should.have.key(key_name).being or "
+    ("this(dictionary).should.have.key(key_name).being or "
      ".with_value should allow chain up")
 
     jay = dict(name="John Doe")
@@ -433,7 +433,7 @@ def test_have_key_with_value():
 
 
 def test_look_like():
-    (u"this('   aa  \n  ').should.look_like('aa')")
+    ("this('   aa  \n  ').should.look_like('aa')")
 
     assert this('   \n  aa \n  ').should.look_like('AA')
     assert this('   \n  bb \n  ').should_not.look_like('aa')
@@ -452,7 +452,7 @@ def test_look_like():
 
 
 def test_equal_with_repr_of_complex_types_and_unicode():
-    (u"test usage of repr() inside expect(complex1).to.equal(complex2)")
+    ("test usage of repr() inside expect(complex1).to.equal(complex2)")
 
     class Y(object):
         def __init__(self, x):
@@ -470,19 +470,19 @@ def test_equal_with_repr_of_complex_types_and_unicode():
 
     y1 = dict(
         a=2,
-        b=Y(u'Gabriel Falcão'),
+        b=Y('Gabriel Falcão'),
         c='Foo',
     )
 
     expect(y1).to.equal(dict(
         a=2,
-        b=Y(u'Gabriel Falcão'),
+        b=Y('Gabriel Falcão'),
         c='Foo',
     ))
 
 
 def test_equal_with_repr_of_complex_types_and_repr():
-    (u"test usage of repr() inside expect(complex1).to.equal(complex2)")
+    ("test usage of repr() inside expect(complex1).to.equal(complex2)")
 
     class Y(object):
         def __init__(self, x):
@@ -500,33 +500,33 @@ def test_equal_with_repr_of_complex_types_and_repr():
 
     y1 = {
         'a': 2,
-        'b': Y(u'Gabriel Falcão'),
+        'b': Y('Gabriel Falcão'),
         'c': 'Foo',
     }
 
     expect(y1).to.equal({
         'a': 2,
-        'b': Y(u'Gabriel Falcão'),
+        'b': Y('Gabriel Falcão'),
         'c': 'Foo',
     })
 
     expect(y1).to_not.equal({
         'a': 2,
-        'b': Y(u'Gabriel Falçao'),
+        'b': Y('Gabriel Falçao'),
         'c': 'Foo',
     })
 
     def opposite():
         expect(y1).to.equal({
             'a': 2,
-            'b': Y(u'Gabriel Falçao'),
+            'b': Y('Gabriel Falçao'),
             'c': 'Foo',
         })
 
     def opposite_not():
         expect(y1).to_not.equal({
             'a': 2,
-            'b': Y(u'Gabriel Falcão'),
+            'b': Y('Gabriel Falcão'),
             'c': 'Foo',
         })
 
@@ -535,11 +535,11 @@ def test_equal_with_repr_of_complex_types_and_repr():
 
     expect(opposite_not).when.called.to.throw(AssertionError)
     expect(opposite_not).when.called.to.throw(compat_repr(
-        u"{'a': 2, 'b': Gabriel Falcão, 'c': 'Foo'} should differ to {'a': 2, 'b': Gabriel Falcão, 'c': 'Foo'}, but is the same thing"))
+        "{'a': 2, 'b': Gabriel Falcão, 'c': 'Foo'} should differ to {'a': 2, 'b': Gabriel Falcão, 'c': 'Foo'}, but is the same thing"))
 
 
 def test_match_regex():
-    (u"expect('some string').to.match(r'\w{4} \w{6}') matches regex")
+    ("expect('some string').to.match(r'\w{4} \w{6}') matches regex")
 
     assert this("some string").should.match(r"\w{4} \w{6}")
     assert this("some string").should_not.match(r"^\d*$")
@@ -560,7 +560,7 @@ def test_match_regex():
 
 
 def test_match_contain():
-    (u"expect('some string').to.contain('tri')")
+    ("expect('some string').to.contain('tri')")
 
     assert this("some string").should.contain("tri")
     assert this("some string").should_not.contain('foo')

--- a/tests/test_old_api.py
+++ b/tests/test_old_api.py
@@ -524,7 +524,7 @@ def test_that_contains_none():
 
     assert that(assertions).raises(
         TypeError,
-        u"'in <string>' requires string as left operand, not NoneType",
+        "'in <string>' requires string as left operand, not NoneType",
     )
 
 
@@ -537,7 +537,7 @@ def test_that_none_contains_string():
     except Exception as e:
         assert_equals(
             text_type(e),
-            u"argument of type 'NoneType' is not iterable",
+            "argument of type 'NoneType' is not iterable",
         )
 
 
@@ -621,7 +621,7 @@ def test_within_fail():
     import time
     from sure import within, miliseconds
 
-    def sleepy():
+    def sleepy(*a):
         time.sleep(0.7)
 
     failed = False
@@ -727,7 +727,7 @@ def test_within_pass_utc():
 
 
 def test_that_is_a_matcher_should_absorb_callables_to_be_used_as_matcher():
-    u"that.is_a_matcher should absorb callables to be used as matcher"
+    "that.is_a_matcher should absorb callables to be used as matcher"
     @that.is_a_matcher
     def is_truthful(what):
         assert bool(what), '%s is so untrue' % (what)
@@ -1439,15 +1439,15 @@ def test_deep_equals_dict_level3_fails_different_key():
     "that() deep_equals(dict) failing on level 3 when has an extra key"
 
     something = {
-        u'my::all_users': [
-            {u'name': u'John', u'age': 33, u'foo': u'bar'},
+        'my::all_users': [
+            {'name': 'John', 'age': 33, 'foo': 'bar'},
         ],
     }
 
     def assertions():
         assert that(something).deep_equals({
-            u'my::all_users': [
-            {u'name': u'John', u'age': 33, u'bar': u'foo'},
+            'my::all_users': [
+            {'name': 'John', 'age': 33, 'bar': 'foo'},
             ],
         })
 
@@ -1482,7 +1482,7 @@ def test_deep_equals_list_level2_fail_by_length_x_gt_y():
 def test_deep_equals_list_level2_fail_by_length_y_gt_x():
     "that(list) deep_equals(list) failing by length (len(Y) > len(X))"
 
-    something = [u'one', u'yeah']
+    something = ['one', 'yeah']
 
     def assertions():
         assert that(something).deep_equals(['one', 'yeah', 'damn'])
@@ -1513,10 +1513,10 @@ def test_function_decorated_with_wip_should_set_a_flag():
 def test_that_equals_fails():
     "that() equals(string) when it's supposed to fail"
 
-    something = u"else"
+    something = "else"
 
     def fail():
-        assert that(u'something').equals(something)
+        assert that('something').equals(something)
 
     assert that(fail).raises(
         AssertionError, compat_repr(
@@ -1549,9 +1549,9 @@ def test_deep_equals_weird():
     part1 = [
         ('Bootstraping Redis role', []),
         ('Restart scalarizr', []),
-        ('Rebundle server', [u'rebundle']),
-        ('Use new role', [u'rebundle']),
-        ('Restart scalarizr after bundling', [u'rebundle']),
+        ('Rebundle server', ['rebundle']),
+        ('Use new role', ['rebundle']),
+        ('Restart scalarizr after bundling', ['rebundle']),
         ('Bundling data', []),
         ('Modifying data', []),
         ('Reboot server', []),
@@ -1559,19 +1559,19 @@ def test_deep_equals_weird():
         ('Setup replication', []),
         ('Restart scalarizr in slave', []),
         ('Slave force termination', []),
-        ('Slave delete EBS', [u'ec2']),
-        ('Setup replication for EBS test', [u'ec2']),
+        ('Slave delete EBS', ['ec2']),
+        ('Setup replication for EBS test', ['ec2']),
         ('Writing on Master, reading on Slave', []),
         ('Slave -> Master promotion', []),
-        ('Restart farm', [u'restart_farm']),
+        ('Restart farm', ['restart_farm']),
     ]
 
     part2 = [
-        ('Bootstraping Redis role', [u'rebundle', u'rebundle', u'rebundle']),
+        ('Bootstraping Redis role', ['rebundle', 'rebundle', 'rebundle']),
         ('Restart scalarizr', []),
-        ('Rebundle server', [u'rebundle']),
-        ('Use new role', [u'rebundle']),
-        ('Restart scalarizr after bundling', [u'rebundle']),
+        ('Rebundle server', ['rebundle']),
+        ('Use new role', ['rebundle']),
+        ('Restart scalarizr after bundling', ['rebundle']),
         ('Bundling data', []),
         ('Modifying data', []),
         ('Reboot server', []),
@@ -1579,11 +1579,11 @@ def test_deep_equals_weird():
         ('Setup replication', []),
         ('Restart scalarizr in slave', []),
         ('Slave force termination', []),
-        ('Slave delete EBS', [u'ec2']),
-        ('Setup replication for EBS test', [u'ec2']),
+        ('Slave delete EBS', ['ec2']),
+        ('Setup replication for EBS test', ['ec2']),
         ('Writing on Master, reading on Slave', []),
         ('Slave -> Master promotion', []),
-        ('Restart farm', [u'restart_farm']),
+        ('Restart farm', ['restart_farm']),
     ]
 
     expect(that(part1).equals).when.called_with(part2).should.throw("")

--- a/tests/test_safe_repr.py
+++ b/tests/test_safe_repr.py
@@ -10,7 +10,7 @@ from sure.six import compat_repr, PY3
 
 def test_basic_list():
     "safe_repr should display a simple list"
-    X = [u'one', u'yeah']
+    X = ['one', 'yeah']
     expect(safe_repr(X)).should.equal(compat_repr(
         "['one', 'yeah']"
     ))
@@ -18,7 +18,7 @@ def test_basic_list():
 
 def test_basic_dict():
     "safe_repr should return a sorted repr"
-    X = {u'b': u'd', u'a': u'c'}
+    X = {'b': 'd', 'a': 'c'}
     expect(safe_repr(X)).should.equal(compat_repr(
         "{'a': 'c', 'b': 'd'}"
     ))
@@ -26,7 +26,7 @@ def test_basic_dict():
 
 def test_nested_dict():
     "dicts nested inside values should also get sorted"
-    X = {u'my::all_users': [{u'age': 33, u'name': u'John', u'foo': u'bar'}]}
+    X = {'my::all_users': [{'age': 33, 'name': 'John', 'foo': 'bar'}]}
     expect(safe_repr(X)).should.equal(compat_repr(
         '''{'my::all_users': [{'age': 33, 'foo': 'bar', 'name': 'John'}]}'''
     ))
@@ -50,10 +50,10 @@ def test_unicode():
 
     y1 = {
         'a': 2,
-        'b': Y(u'Gabriel Falcão'),
-        'c': u'Foo',
+        'b': Y('Gabriel Falcão'),
+        'c': 'Foo',
     }
-    name = u'Gabriel Falcão' if PY3 else u'Gabriel Falc\xe3o'
+    name = 'Gabriel Falcão' if PY3 else 'Gabriel Falc\xe3o'
 
     expect(safe_repr(y1)).should.equal(compat_repr(
         "{'a': 2, 'b': %s, 'c': 'Foo'}" % name


### PR DESCRIPTION
It is useless, and prevents the code from working on Python 3.2.
