### PR TITLE
add tests to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include requirements.txt
 include README.md
 include README.rst
+recursive-include tests *.py


### PR DESCRIPTION
Add the test suite to the sdist so that packagers and people who like to
verify they have their environment setup correctly can run the tests.
