### PR TITLE
compare floats with epsilon

### DIFF
--- a/spec/reference.md
+++ b/spec/reference.md
@@ -14,6 +14,18 @@ import sure
 (3).shouldnt.be.equal(5)
 ```
 
+### (float).should.equal(float, epsilon)
+
+```python
+import sure
+
+(4.242423).should.be.equal(4.242420, epsilon=0.000005)
+(4.01).should.be.eql(4.00, epsilon=0.01)
+(6.3699999).should.equal(6.37, epsilon=0.001)
+
+(4.242423).shouldnt.be.equal(4.249000, epsilon=0.000005)
+```
+
 ## Compare strings with diff
 
 ### (string).should_not.be.different_of(string)

--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -595,9 +595,9 @@ class AssertionBuilder(object):
             return collection_should.contains(self.obj)
 
     @assertionmethod
-    def equal(self, what):
+    def equal(self, what, epsilon=None):
         try:
-            comparison = DeepComparison(self.obj, what).compare()
+            comparison = DeepComparison(self.obj, what, epsilon).compare()
             error = False
         except AssertionError as e:
             error = e

--- a/sure/core.py
+++ b/sure/core.py
@@ -106,19 +106,21 @@ class DeepExplanation(text_type):
 
 
 class DeepComparison(object):
-    def __init__(self, X, Y, parent=None):
+    def __init__(self, X, Y, epsilon=None, parent=None):
         self.operands = X, Y
+        self.epsilon = epsilon
         self.parent = parent
         self._context = None
 
     def is_simple(self, obj):
         return isinstance(obj, (
-            float, string_types, integer_types
+            string_types, integer_types
         ))
 
     def compare_complex_stuff(self, X, Y):
         kind = type(X)
         mapping = {
+            float: self.compare_floats,
             dict: self.compare_dicts,
             list: self.compare_iterables,
             tuple: self.compare_iterables,
@@ -131,6 +133,17 @@ class DeepComparison(object):
             return True
         else:
             m = 'X%s != Y%s' % (red(c.current_X_keys), green(c.current_Y_keys))
+            return DeepExplanation(m)
+
+    def compare_floats(self, X, Y):
+        c = self.get_context()
+        if self.epsilon is None:
+            return self.compare_generic(X, Y)
+
+        if abs(X - Y) <= self.epsilon:
+            return True
+        else:
+            m = 'X%s±%s != Y%s±%s' % (red(c.current_X_keys), self.epsilon, green(c.current_Y_keys), self.epsilon)
             return DeepExplanation(m)
 
     def compare_dicts(self, X, Y):
@@ -167,6 +180,7 @@ class DeepComparison(object):
                 child = DeepComparison(
                     value_X,
                     value_Y,
+                    epsilon=self.epsilon,
                     parent=self,
                 ).compare()
                 if isinstance(child, DeepExplanation):
@@ -215,6 +229,7 @@ class DeepComparison(object):
                 child = DeepComparison(
                     value_X,
                     value_Y,
+                    epsilon=self.epsilon,
                     parent=self,
                 ).compare()
                 if isinstance(child, DeepExplanation):

--- a/tests/test_assertion_builder.py
+++ b/tests/test_assertion_builder.py
@@ -683,3 +683,24 @@ def test_equals_handles_mock_call_list():
         mock.call(a=1, b=2),
         mock.call(a=3, b=4),
     ])
+
+
+def test_equals_handles_float_with_epsilon():
+    ".equal(what, epsilon=XXX) should check for equality with an epsilon for float values"
+    float1 = 4.242423
+    float2 = 4.242420
+
+    expect(float1).should_not.be.equal(float2)
+    expect(float1).should.be.equal(float2, epsilon=0.000005)
+
+    float_list1 = [4.242421, 4.242422, 4.242423, 4.242424, 4.242425]
+    float_list2 = [4.242420, 4.242420, 4.242420, 4.242420, 4.242420]
+
+    expect(float_list1).should_not.be.equal(float_list2)
+    expect(float_list1).should.be.equal(float_list2, epsilon=0.000005)
+
+    float_dict1 = {"f1": 4.242421, "f2": 4.242422, "f3": 4.242423, "f4": 4.242424, "f5": 4.242425}
+    float_dict2 = {"f1": 4.242420, "f2": 4.242420, "f3": 4.242420, "f4": 4.242420, "f5": 4.242420}
+
+    expect(float_dict1).should_not.be.equal(float_dict2)
+    expect(float_dict1).should.be.equal(float_dict2, epsilon=0.000005)


### PR DESCRIPTION
I think it would be cool to have the possibility to check floats for equality with a given epsilon.
I've implemented it as a new `compare_` method in the `DeepComparison` class. 
The `epsilon` for the comparison is given to the constructor of the `DeepComparison` class.
Test and specs are updated as well!

:beers: 
