### PR TITLE
make python 3 compatible again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
 
 # command to install dependencies
 install:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ import sure
 
 (4).should.be.equal(2 + 2)
 (7.5).should.eql(3.5 + 4)
-(2).should.equal(8 / 4)
 
 (3).shouldnt.be.equal(5)
 ```

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-sure ``1.2.7``
+sure ``1.2.8``
 ==============
 
 A testing library for python with powerful and flexible assertions. Sure

--- a/spec/reference.md
+++ b/spec/reference.md
@@ -300,6 +300,33 @@ if PY3:
 else:
     range.when.called_with(10, step="20").should.throw(TypeError, "range() takes no keyword arguments")
     range.when.called_with(b"chuck norris").should.throw("range() integer end argument expected, got str.")
+range.when.called_with("chuck norris").should.have.raised(TypeError)
+range.when.called_with(10).should_not.have.raised(TypeError)
+```
+
+You can also match regular expressions with to the expected exception messages:
+
+```python
+import re
+range.when.called_with(10, step=20).should.throw(TypeError, re.compile(r'(does not take|takes no) keyword arguments'))
+range.when.called_with("chuck norris").should.throw(TypeError, re.compile(r'(cannot be interpreted as an integer|integer end argument expected)'))
+```
+
+### callable.when.called_with(arg1, kwarg1=2).should.throw(Exception)
+
+You can use this feature to assert that a callable raises an
+exception:
+
+```python
+import sure
+from six import PY3
+
+if PY3:
+    range.when.called_with(10, step=20).should.throw(TypeError, "range() does not take keyword arguments")
+    range.when.called_with("chuck norris").should.throw(TypeError, "'str' object cannot be interpreted as an integer")
+else:
+    range.when.called_with(10, step="20").should.throw(TypeError, "range() takes no keyword arguments")
+    range.when.called_with(b"chuck norris").should.throw("range() integer end argument expected, got str.")
 range.when.called_with("chuck norris").should.throw(TypeError)
 range.when.called_with(10).should_not.throw(TypeError)
 ```
@@ -321,7 +348,7 @@ result
 ```python
 import sure
 
-list.when.called_with([0, 1]).should.return_value([0, 1])
+list.when.called_with([0, 1]).should.have.returned_the_value([0, 1])
 ```
 
 this is the same as

--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -803,10 +803,15 @@ class AssertionBuilder(object):
 
         return _that.raises(*args, **kw)
 
+    thrown = throw
+    raised = thrown
+
     @assertionmethod
     def return_value(self, value):
         return_value = self.obj(*self._callable_args, **self._callable_kw)
         return this(return_value).should.equal(value)
+
+    returned_the_value = return_value
 
     @assertionmethod
     def look_like(self, value):

--- a/sure/old.py
+++ b/sure/old.py
@@ -42,10 +42,10 @@ from sure.core import itemize_length
 
 
 def identify_callable_location(callable_object):
-    filename = os.path.relpath(callable_object.func_code.co_filename)
-    lineno = callable_object.func_code.co_firstlineno
-    callable_name = callable_object.func_code.co_name
-    return b'{0} [{1} line {2}]'.format(callable_name, filename, lineno)
+    filename = os.path.relpath(callable_object.__code__.co_filename)
+    lineno = callable_object.__code__.co_firstlineno
+    callable_name = callable_object.__code__.co_name
+    return '{0} [{1} line {2}]'.format(callable_name, filename, lineno).encode()
 
 
 def is_iterable(obj):

--- a/tests/test_assertion_builder.py
+++ b/tests/test_assertion_builder.py
@@ -648,13 +648,19 @@ def test_throw_matching_regex():
         raise RuntimeError('should not have reached here')
 
     except AssertionError as e:
-        expect(str(e)).to.equal("When calling 'blah [tests/test_assertion_builder.py line 633]' the exception message does not match. Expected to match regex: u'invalid regex'\n against:\n u'this message'")
+        if PY3:
+            expect(str(e)).to.equal("When calling b'blah [tests/test_assertion_builder.py line 633]' the exception message does not match. Expected to match regex: 'invalid regex'\n against:\n 'this message'")
+        else:
+            expect(str(e)).to.equal("When calling 'blah [tests/test_assertion_builder.py line 633]' the exception message does not match. Expected to match regex: u'invalid regex'\n against:\n u'this message'")
 
     try:
         expect(blah).when.called_with(1).should.throw(ValueError, re.compile(r'invalid regex'))
         raise RuntimeError('should not have reached here')
     except AssertionError as e:
-        expect(str(e)).to.equal("When calling 'blah [tests/test_assertion_builder.py line 633]' the exception message does not match. Expected to match regex: u'invalid regex'\n against:\n u'this message'")
+        if PY3:
+            expect(str(e)).to.equal("When calling b'blah [tests/test_assertion_builder.py line 633]' the exception message does not match. Expected to match regex: 'invalid regex'\n against:\n 'this message'")
+        else:
+            expect(str(e)).to.equal("When calling 'blah [tests/test_assertion_builder.py line 633]' the exception message does not match. Expected to match regex: u'invalid regex'\n against:\n u'this message'")
 
 def test_should_not_be_different():
     ("'something'.should_not.be.different('SOMETHING'.lower())")


### PR DESCRIPTION
I have done some fixes which gives python 3 compatibility back to `sure`!

The `function` objects in python 3 have no `func_code` member anymore. Use `__code__` instead.
The `byte` objects in python 3 have no `format` method. Use `encode` instead.
The representation of the strings and encoded strings are different in python 2 and python 3 thus use PY3 from six.
Remove unluckily example from README since python 3 returns a float and python 2 an int in this situation

**Python 2 and 3 build is working again!**

:beers: 