### PR TITLE
Fix encoding when installing with pip3/Python3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 
 import ast
 import os
+import sys
 from setuptools import setup, find_packages
 
 
@@ -42,7 +43,8 @@ def read_version():
 
 
 local_file = lambda *f: \
-    open(os.path.join(os.path.dirname(__file__), *f)).read()
+    open(os.path.join(os.path.dirname(__file__), *f)).read() if sys.version_info < (3, 0, 0) else \
+    open(os.path.join(os.path.dirname(__file__), *f), encoding='utf-8').read()
 
 
 install_requires = ['mock', 'six']


### PR DESCRIPTION
I've encountered issue #63  on 2 separate Ubuntu 14.04 boxes, one of which is a very recent Digital Ocean Ubuntu 14.04 image. I've only seen it on Ubuntu, the default encoding for python 3.4 on OS X 10.10 is already ```UTF-8``` and i haven't had the time to try reproducing it on other distro's.

It appears that if you don't explicitly set the encoding with locale.setlocale(locale.LC_ALL, 'en_US.utf-8') --- or whatever locale, just the encoding matters AFAIK --- python will try to decode using ascii (the locale.getpreferredencoding(False) function that open() actually depends on for the type of encoding it uses returns ```ANSI_X3.4-1968``` on the Ubuntu 14.04 boxes i encountered this on). This creates an issue where Python will say it cannot decode files using ascii and the installation will fail.

This is a possible fix that checks whether the python version is < (3, 0, 0) and enforces encoding to ```utf-8``` if not < (3, 0, 0) by adding ```encoding='utf-8'``` to open() calls as the second parameter. I've tested it with Python 2.7 and 3.4. Hope it helps.