### PR TITLE
Add same python versions to tox and travis configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33
+envlist = py26,py27,py33,py34
 
 [testenv]
 commands = nosetests
 deps =
-    git+git://github.com/spulec/steadymark.git@py3k#egg=sure
     nose


### PR DESCRIPTION
tox.init and .travis.yml should test the same python versions.