### PR TITLE
 Revert unicode reading in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@
 import ast
 import os
 import sys
-import codecs
 from setuptools import setup, find_packages
 
 
@@ -43,9 +42,10 @@ def read_version():
     return finder.version
 
 
-def local_file(*f):
-    path = os.path.join(os.path.dirname(__file__), *f)
-    return codecs.open(path, 'r', encoding='utf-8').read()
+def local_file( *f):
+    if sys.version_info < (3, 0, 0):
+        return open(os.path.join(os.path.dirname(__file__), *f)).read()
+    return open(os.path.join(os.path.dirname(__file__), *f), encoding="utf-8").read()
 
 
 install_requires = ['mock', 'six']


### PR DESCRIPTION
This patch seems breaks the python 2 tests and builds.
What was the reason for this?
Without this change sure is installable in python 2 and 3.