### PR TITLE
Treat python 2 as special case

### DIFF
--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -28,7 +28,7 @@ import traceback
 from functools import wraps
 from datetime import datetime
 
-from six import string_types, text_type, PY3, get_function_code
+from six import string_types, text_type, PY2, get_function_code
 from six.moves import reduce
 
 from sure.old import AssertionHelper
@@ -45,7 +45,7 @@ from sure.magic import is_cpython, patchable_builtin
 from sure.registry import context as _registry
 
 
-if PY3:
+if not PY2:
     basestring = str
 
 version = '1.2.24'
@@ -185,11 +185,11 @@ def within(**units):
             try:
                 func(start, *args, **kw)
             except TypeError as e:
-                if PY3:
-                    # PY3 has different error message
-                    fmt = '{0}() takes 0 positional arguments but 1 was given'
-                else:
+                if PY2:
+                    # PY2 has different error message
                     fmt = '{0}() takes no arguments'
+                else:
+                    fmt = '{0}() takes 0 positional arguments but 1 was given'
                 err = text_type(e)
                 if fmt.format(func.__name__) in err:
                     func(*args, **kw)
@@ -387,7 +387,7 @@ def assertionmethod(func):
             ", ".join(map(safe_repr, args)),
             ", ".join(["{0}={1}".format(k, safe_repr(kw[k])) for k in kw]),
         )
-        if not PY3:
+        if PY2:
             msg = text_type(msg)
 
         assert value, msg

--- a/sure/compat_py3.py
+++ b/sure/compat_py3.py
@@ -1,9 +1,6 @@
 import six
 
-if six.PY3:
-    def compat_repr(object_repr):
-        return object_repr
-else:
+if six.PY2:
     def compat_repr(object_repr):
         # compat_repr is designed to return all reprs with leading 'u's
         # inserted to make all strings look like unicode strings.
@@ -25,5 +22,8 @@ else:
                     in_quote = True
             result += char
         return result
+else:
+    def compat_repr(object_repr):
+        return object_repr
 
 text_type_name = six.text_type().__class__.__name__

--- a/sure/core.py
+++ b/sure/core.py
@@ -28,11 +28,11 @@ try:
     from mock import _CallList
 except ImportError:
     from mock.mock import _CallList
-    
+
 import inspect
 from six import (
     text_type, integer_types, string_types, binary_type,
-    PY3, get_function_code
+    PY2, get_function_code
 )
 from sure.terminal import red, green, yellow
 
@@ -48,18 +48,18 @@ class FakeOrderedDict(OrderedDict):
         key_values = []
         for key, value in self.items():
             key, value = repr(key), repr(value)
-            if isinstance(value, binary_type) and not PY3:
+            if isinstance(value, binary_type) and PY2:
                 value = value.decode("utf-8")
             key_values.append("{0}: {1}".format(key, value))
         res = "{{{0}}}".format(", ".join(key_values))
         return res
 
-    if PY3:
-        def __repr__(self):
-            return self.__unicode__()
-    else:
+    if PY2:
         def __repr__(self):
             return self.__unicode__().encode('utf-8')
+    else:
+        def __repr__(self):
+            return self.__unicode__()
 
 
 def _obj_with_safe_repr(obj):
@@ -86,7 +86,7 @@ def safe_repr(val):
             # significantly easier
             val = _obj_with_safe_repr(val)
         ret = repr(val)
-        if not PY3:
+        if PY2:
             ret = ret.decode('utf-8')
     except UnicodeEncodeError:
         ret = red('a %r that cannot be represented' % type(val))


### PR DESCRIPTION
Assume python 3 as default for code base and treat python 2 as special case. 
This has the benefit that we do not have to change to code base for further python versions as they are more likely to be the same as python 3 then python 2. (if it is different to both - it'll be a whole different story...)

```python
if six.PY3:
   # implement it for python 3
else:
   # implement it for python 2
```

If there is a python 4 version it is probably the same like python 3 so you could either add the python 4 check to the if or change it as the following:


```python
if six.PY2:
   # implement it for python 2
else:
   # implement it for python 3 and 4
```