### PR TITLE
Mark python 2.6 as deprecated

### DIFF
--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -51,6 +51,18 @@ if PY3:
 version = '1.2.24'
 
 
+def print_py26_deprecation_warn():
+    # warn the user if sure is used with python 2.6.
+    # sure will remove python 2.6 support in the next version.
+    # make sure to remove this code as soon as the python 2.6 support is removed
+    if sys.version_info.major == 2 and sys.version_info.minor == 6:
+        import warnings
+        warnings.simplefilter("always", PendingDeprecationWarning)
+        warnings.warn("The next version of sure will NO LONGER support python 2.6", PendingDeprecationWarning)
+
+print_py26_deprecation_warn()
+
+
 not_here_error = \
     'you have tried to access the attribute %r from the context ' \
     '(aka VariablesBag), but there is no such attribute assigned to it. ' \

--- a/tests/test_py26_deprecation.py
+++ b/tests/test_py26_deprecation.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import warnings
+
+from mock import patch
+
+
+def test_deprecation_warning_py26():
+    """test deprecation warning in python 2.6"""
+    with patch("sys.version_info") as version_info_patch, warnings.catch_warnings(record=True) as captured_warnings:
+        from sure import print_py26_deprecation_warn
+
+        # do not expect deprecation warning if python 2.7
+        version_info_patch.major = 2
+        version_info_patch.minor = 7
+        print_py26_deprecation_warn()
+        captured_warnings.should.be.empty
+
+        # expect deprecation warning if python 2.6
+        version_info_patch.major = 2
+        version_info_patch.minor = 6
+        print_py26_deprecation_warn()
+
+        captured_warnings.should.have.length_of(1)
+        captured_warnings[0].category.should.be.equal(PendingDeprecationWarning)
+        str(captured_warnings[0].message).should.be.equal("The next version of sure will NO LONGER support python 2.6")


### PR DESCRIPTION
Print `PendingDeprecationWarning` if sure is used with python 2.6
Make sure to remove this code when removing python 2.6 support.

Refers Issue #97 