### PR TITLE
Include license file and tox.ini in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
-include requirements.txt
+include requirements.txt tox.ini
+include COPYING
 include README.md
 include README.rst
 recursive-include tests *.py


### PR DESCRIPTION
Allows automated detection and packaging of license data by tools such as spdx-lookup and an optional extra method (tox) for running QA downstream for users an OS packagers