### PR TITLE
Resolve py35 tox failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ import codecs
 from setuptools import setup, find_packages
 
 
+PROJECT_ROOT = os.path.dirname(__file__)
+
+
 class VersionFinder(ast.NodeVisitor):
 
     def __init__(self):
@@ -37,15 +40,22 @@ class VersionFinder(ast.NodeVisitor):
 
 
 def read_version():
-    """Read version from sure/version.py without loading any files"""
+    """Read version from sure/__init__.py without loading any files"""
     finder = VersionFinder()
-    finder.visit(ast.parse(local_file('sure', '__init__.py')))
+    path = os.path.join(PROJECT_ROOT, 'sure', '__init__.py')
+    with codecs.open(path, 'r', encoding='utf-8') as fp:
+        file_data = fp.read().encode('utf-8')
+        finder.visit(ast.parse(file_data))
+
     return finder.version
 
 
-def local_file(*f):
-    path = os.path.join(os.path.dirname(__file__), *f)
-    return codecs.open(path, 'r', encoding='utf-8').read().encode('utf-8')
+def local_text_file(*f):
+    path = os.path.join(PROJECT_ROOT, *f)
+    with open(path, 'rt') as fp:
+        file_data = fp.read()
+
+    return file_data
 
 
 install_requires = ['mock', 'six']
@@ -57,7 +67,7 @@ if __name__ == '__main__':
           version=read_version(),
           description='utility belt for automated testing in python for python',
           author='Gabriel Falcao',
-          long_description=local_file('README.rst'),
+          long_description=local_text_file('README.rst'),
           author_email='gabriel@nacaolivre.org',
           include_package_data=True,
           url='http://github.com/gabrielfalcao/sure',


### PR DESCRIPTION
Separate the logic that reads the version number, using the codecs
module, from the logic that reads text files.

With this change; running `tox` succeeds for all the supported environments (i.e. 2.7 and 3.5).

```
$ tox
GLOB sdist-make: /Users/admin/Development/github/guyhoozdis/sure/setup.py
py27 inst-nodeps: /Users/admin/Development/github/guyhoozdis/sure/.tox/dist/sure-1.2.24.zip
py27 installed: cffi==1.6.0,couleur==0.6.2,funcsigs==1.0.2,misaka==2.0.0,mock==2.0.0,nose==1.3.7,pbr==1.9.1,pycparser==2.14,six==1.10.0,steadymark==0.7.3,sure==1.2.24
py27 runtests: PYTHONHASHSEED='1430052655'
py27 runtests: commands[0] | nosetests
.............................................................................................................................
----------------------------------------------------------------------
Ran 125 tests in 0.775s

OK
py35 inst-nodeps: /Users/admin/Development/github/guyhoozdis/sure/.tox/dist/sure-1.2.24.zip
py35 installed: cffi==1.6.0,couleur==0.6.2,misaka==2.0.0,mock==2.0.0,nose==1.3.7,pbr==1.9.1,pycparser==2.14,six==1.10.0,steadymark==0.7.3,sure==1.2.24
py35 runtests: PYTHONHASHSEED='1430052655'
py35 runtests: commands[0] | nosetests
.............................................................................................................................
----------------------------------------------------------------------
Ran 125 tests in 0.806s

OK
________________________________________ summary ________________________________________
  py27: commands succeeded
  py35: commands succeeded
  congratulations :)
```

----

The [problem][reading-from-files] appears to have started with the following changesets:

 1. https://github.com/gabrielfalcao/sure/commit/08db21173c0dfa597124d66d411006360a233d5b - Fix python3 setup.py file read encoding issue.
 1. https://github.com/gabrielfalcao/sure/commit/cd511b5bd0114f26be9f03b8123ca127b4e4d080 - always loading files as utf-8 in setup.py

After reviewing those changes; it appears that using the `codecs` module was a deliberate effort, so I preserved that behavior.  Since that behavior was specific to reading python modules I refactored that logic into the `read_version` method.

To avoid confusion I changed the name of the `local_file` method to `local_text_file`.  This method uses the built-in method `open`, but as [described here][reading-from-files] it might be preferable to use `io.open` instead.

[reading-from-files]: http://python3porting.com/problems.html#reading-from-files