### PR TITLE
Provide possibility to extend sure. Refs #31

### DIFF
--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -921,6 +921,13 @@ those = AssertionBuilder('those')
 expect = AssertionBuilder('expect')
 
 
+def assertion(func):
+    """Extend sure with a custom assertion method."""
+    func = assertionmethod(func)
+    setattr(AssertionBuilder, func.__name__, func)
+    return func
+
+
 allows_new_syntax = not os.getenv('SURE_DISABLE_NEW_SYNTAX')
 
 

--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -933,6 +933,12 @@ def chain(func):
     setattr(AssertionBuilder, func.__name__, func)
     return func
 
+def chainproperty(func):
+    """Extend sure with a custom chain property."""
+    func = assertionproperty(func)
+    setattr(AssertionBuilder, func.fget.__name__, func)
+    return func
+
 
 allows_new_syntax = not os.getenv('SURE_DISABLE_NEW_SYNTAX')
 

--- a/sure/__init__.py
+++ b/sure/__init__.py
@@ -928,6 +928,12 @@ def assertion(func):
     return func
 
 
+def chain(func):
+    """Extend sure with a custom chaining method."""
+    setattr(AssertionBuilder, func.__name__, func)
+    return func
+
+
 allows_new_syntax = not os.getenv('SURE_DISABLE_NEW_SYNTAX')
 
 

--- a/tests/test_custom_assertions.py
+++ b/tests/test_custom_assertions.py
@@ -4,7 +4,7 @@
 Test custom assertions.
 """
 
-from sure import expect, assertion, chain
+from sure import expect, assertion, chain, chainproperty
 from sure.magic import is_cpython
 
 
@@ -54,3 +54,35 @@ def test_custom_chain_method():
         Response({"foo": "bar", "bar": "foo"}, 200).should.have.header("foo").must.be.equal("bar")
     else:
         expect(expect(Response({"foo": "bar", "bar": "foo"}, 200)).should.have.header("foo")).must.be.equal("bar")
+
+
+def test_custom_chain_property():
+    "test extending sure with a custom chain property."
+
+    class Response(object):
+        magic = 41
+
+    @chainproperty
+    def having(self):
+        return self
+
+    @chainproperty
+    def implement(self):
+        return self
+
+
+    @assertion
+    def attribute(self, name):
+        has_it = hasattr(self.obj, name)
+        if self.negative:
+            assert not has_it, "Expected was that object {0} does not have attribute {1}".format(
+                self.obj, name)
+        else:
+            assert has_it, "Expected was that object {0} has attribute {1}".format(
+                self.obj, name)
+
+        return True
+
+
+    expect(Response).having.attribute("magic")
+    expect(Response).doesnt.implement.attribute("nomagic")

--- a/tests/test_custom_assertions.py
+++ b/tests/test_custom_assertions.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""
+Test custom assertions.
+"""
+
+from sure import expect, assertion
+
+
+def test_custom_assertion():
+    "test extending sure with a custom assertion."
+
+    class Response(object):
+        def __init__(self, return_code):
+            self.return_code = return_code
+
+
+    @assertion
+    def return_code(self, return_code):
+        if self.negative:
+            assert return_code != self.obj.return_code, "Expected was a return code different from {0}.".format(return_code)
+        else:
+            assert return_code == self.obj.return_code, "Expected return code is: {0}\nGiven return code was: {1}".format(
+                return_code, self.obj.return_code)
+
+        return True
+
+
+    expect(Response(200)).should.have.return_code(200)
+    expect(Response(200)).shouldnt.have.return_code(201)


### PR DESCRIPTION
*__Note__: work in progress*

This PR contains the following features:

- [x] Add decorator to extend sure with a custom assertion method
- [x] Add decorator to extend sure with a chain method
- [ ] Add decorator to extend sure with a chain property

**Other Todos:**

- [ ] Enforce beauty of assertion error message. How? Provide specific `Exception`: `class Assertion(AssertionError): pass` which takes *expected* and *given* arguments? Is it just best practice?
- [ ] Enforce negative check. How? Is it just best practice?
- [ ] Documentation / Tutorial

## Custom assertion example

```python
from sure import assertion


class Response(object):
    def __init__(self, return_code):
        self.return_code = return_code


@assertion
def return_code(self, return_code):
    if self.negative:
        msg = "Expected was a return code different from {0}."
        assert return_code != self.obj.return_code, msg.format(return_code)
    else:
        msg = "Expected return code is: {0}\nGiven return code was: {1}"
        assert return_code == self.obj.return_code, msg.format(return_code, 
            self.obj.return_code)

Response(200).should.have.return_code(200)
Response(200).shouldnt.have.return_code(201)
```

@gabrielfalcao please provide feedback regarding API. See first test for entire example usage.

Refs: #31 


