### PR TITLE
Fix assertions for raises

### DIFF
--- a/sure/old.py
+++ b/sure/old.py
@@ -137,7 +137,7 @@ class AssertionHelper(object):
                 if not isinstance(e, exc):
                     raise AssertionError(
                         '%r should raise %r, but raised %r:\nORIGINAL EXCEPTION:\n\n%s' % (
-                            self._src, exc, e.__class__, traceback.format_exc(e)))
+                            self._src, exc, e.__class__, traceback.format_exc()))
 
                 if isinstance(msg, string_types) and msg not in err:
                     raise AssertionError('''

--- a/tests/test_assertion_builder.py
+++ b/tests/test_assertion_builder.py
@@ -20,7 +20,7 @@ import re
 import mock
 from collections import OrderedDict
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from sure import this, these, those, it, expect, anything, AssertionBuilder
 from six import PY3
 from sure.compat import compat_repr
@@ -38,7 +38,7 @@ def test_assertion_builder_synonyms():
 def test_4_equal_2p2():
     ("this(4).should.equal(2 + 2)")
 
-    time = datetime.now()
+    time = datetime.now() - timedelta(0, 60)
 
     assert this(4).should.equal(2 + 2)
     assert this(time).should_not.equal(datetime.now())

--- a/tests/test_old_api.py
+++ b/tests/test_old_api.py
@@ -477,7 +477,7 @@ def test_that_looks_like():
     assert that('String\n with BREAKLINE').looks_like('string with breakline')
 
 
-def test_that_raises_raises_for_wrong_exception_type():
+def test_that_raises_does_raise_for_exception_type_mismatch():
     "that(callable(RuntimeError)).raises(TypeError)"
 
     error = r'.*should raise <class .*FooError.*, but raised <class .*BarError.*'
@@ -493,7 +493,7 @@ def test_that_raises_raises_for_wrong_exception_type():
 
     try:
         assert that(my_function).raises(FooError, 'OOps')
-        assert False    # should never reach here
+        assert False, 'should never reach here'
     except AssertionError as e:
         import re
         assert re.match(error, text_type(e))

--- a/tests/test_old_api.py
+++ b/tests/test_old_api.py
@@ -477,6 +477,28 @@ def test_that_looks_like():
     assert that('String\n with BREAKLINE').looks_like('string with breakline')
 
 
+def test_that_raises_raises_for_wrong_exception_type():
+    "that(callable(RuntimeError)).raises(TypeError)"
+
+    error = r'.*should raise <class .*FooError.*, but raised <class .*BarError.*'
+
+    class FooError(Exception):
+        pass
+
+    class BarError(Exception):
+        pass
+
+    def my_function():
+        raise BarError('OOps')
+
+    try:
+        assert that(my_function).raises(FooError, 'OOps')
+        assert False    # should never reach here
+    except AssertionError as e:
+        import re
+        assert re.match(error, text_type(e))
+
+
 def test_that_raises_with_args():
     "that(callable, with_args=['foo']).raises(FooError)"
 
@@ -895,7 +917,7 @@ def test_depends_on_failing_due_nothing_found():
     from sure import action_for, scenario
 
     fullpath = os.path.abspath(__file__).replace('.pyc', '.py')
-    error = 'the action "lonely_action" defined at %s:904 ' \
+    error = 'the action "lonely_action" defined at %s:926 ' \
         'depends on the attribute "something" to be available in the' \
         ' context. It turns out that there are no actions providing ' \
         'that. Please double-check the implementation' % fullpath
@@ -921,10 +943,10 @@ def test_depends_on_failing_due_not_calling_a_previous_action():
     from sure import action_for, scenario
 
     fullpath = os.path.abspath(__file__).replace('.pyc', '.py')
-    error = 'the action "my_action" defined at {0}:934 ' \
+    error = 'the action "my_action" defined at {0}:956 ' \
         'depends on the attribute "some_attr" to be available in the context.'\
         ' You need to call one of the following actions beforehand:\n' \
-        ' -> dependency_action at {0}:930'.replace('{0}', fullpath)
+        ' -> dependency_action at {0}:952'.replace('{0}', fullpath)
 
     def with_setup(context):
         @action_for(context, provides=['some_attr'])


### PR DESCRIPTION
## Pull Request Type

Please specify the type of the pull request you want to submit:

- [X] Bugfix
- [ ] New Feature
- [ ] Documentation Only
- [ ] Testing Only
- [ ] ...

## Summary

Add test for assertions on exception type mismatch in raises clause. Fix a minor incorrect traceback.format_exc api usage.
Use a past time in assertion builder test to remove test flakiness.