### PR TITLE
Allow overwriting of monkey-patched properties by sure. Closes #19, #74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Last traces of Python 2.6 support
 
 ### Fixed
+- Allow overwriting of monkey-patched properties by sure. Refs #19
 - Assertions for raises
 
 ## [v1.3.0]

--- a/tests/issues/test_issue_19.py
+++ b/tests/issues/test_issue_19.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+"""
+Test fix of bug described in GitHub Issue #19.
+"""
+
+from sure import expect, AssertionBuilder
+from sure.magic import is_cpython
+
+
+def test_issue_19():
+    "Allow monkey-patching of methods already implemented by sure."
+
+    class Foo(object):
+        pass
+
+        @property
+        def should(self):
+            return 42
+
+    instance = Foo()
+    instance.do = "anything"
+    instance.doesnt = "foo"
+
+    expect(instance.do).should.be.equal("anything")
+    expect(instance.doesnt).should.be.equal("foo")
+
+    if is_cpython:
+        instance2 = Foo()
+        instance2.do.shouldnt.be.equal("anything")
+        instance.does.__class__.should.be.equal(AssertionBuilder)
+
+    # remove attribute
+    del instance.do
+
+    if is_cpython:
+        instance.do.shouldnt.be.equal("anything")
+    else:
+        expect(instance).shouldnt.have.property("do")
+
+    if is_cpython:
+        Foo.shouldnt.__class__.should.be.equal(AssertionBuilder)
+
+    Foo.shouldnt = "bar"
+    expect(Foo.shouldnt).should.be.equal("bar")
+    del Foo.shouldnt
+
+    if is_cpython:
+        Foo.shouldnt.__class__.should.be.equal(AssertionBuilder)
+    else:
+        expect(Foo).shouldnt.have.property("shouldnt")
+
+
+    expect(instance.should).should.be.equal(42)


### PR DESCRIPTION
## Pull Request Type

Please specify the type of the pull request you want to submit:

- [x] Bugfix

## Summary

This allows overwriting of the monkey-patched properties by sure in
cpython:

```python

from sure import AssertionBuilder

class Foo(object):
    pass

instance = Foo()
instance.do = "anything"
instance.do.should.be.equal("anything")

instance2 = Foo()
instance2.do.__class__.should.be.equal(AssertionBuilder)
```

This test would pass.

Fixes: #19 , #74 

I'm still looking for better solutions. Like overwriting the property and not look it up in a map but I always ended up with a max recursion error ..
Maybe someone else has a nice idea?