### PR TITLE
Allow crosstype comparsion

### DIFF
--- a/sure/core.py
+++ b/sure/core.py
@@ -35,7 +35,8 @@ from sure.compat import safe_repr, OrderedDict
 
 class Anything(object):
     """Represents any possible value."""
-    pass
+    def __cmp__(self, _):
+        return 0
 
 anything = Anything()
 
@@ -56,6 +57,14 @@ class DeepExplanation(text_type):
 
 class DeepComparison(object):
     def __init__(self, X, Y, epsilon=None, parent=None):
+        self.complex_cmp_funcs = {
+            float: self.compare_floats,
+            dict: self.compare_dicts,
+            list: self.compare_iterables,
+            tuple: self.compare_iterables,
+            OrderedDict: self.compare_ordereddict
+        }
+
         self.operands = X, Y
         self.epsilon = epsilon
         self.parent = parent
@@ -66,23 +75,18 @@ class DeepComparison(object):
             string_types, integer_types, Anything
         ))
 
-    def compare_complex_stuff(self, X, Y):
-        kind = type(X)
-        mapping = {
-            float: self.compare_floats,
-            dict: self.compare_dicts,
-            list: self.compare_iterables,
-            tuple: self.compare_iterables,
-            OrderedDict: self.compare_ordereddict
-        }
-        return mapping.get(kind, self.compare_generic)(X, Y)
+    def is_complex(self, obj):
+        return isinstance(obj, tuple(self.complex_cmp_funcs.keys()))
 
-    def compare_generic(self, X, Y):
+    def compare_complex_stuff(self, X, Y):
+        return self.complex_cmp_funcs.get(type(X), self.compare_generic)(X, Y)
+
+    def compare_generic(self, X, Y, msg_format='X%s != Y%s'):
         c = self.get_context()
         if X == Y:
             return True
         else:
-            m = 'X%s != Y%s' % (red(c.current_X_keys), green(c.current_Y_keys))
+            m = msg_format % (red(c.current_X_keys), green(c.current_Y_keys))
             return DeepExplanation(m)
 
     def compare_floats(self, X, Y):
@@ -213,27 +217,19 @@ class DeepComparison(object):
             X = list(Y)
 
         c = self.get_context()
-        if self.is_simple(X) and self.is_simple(Y):  # both simple
-            if X == Y or anything in (X, Y):
-                return True
-            c = self.get_context()
-            m = "X%s is %%r whereas Y%s is %%r"
-            msg = m % (red(c.current_X_keys), green(c.current_Y_keys)) % (X, Y)
-            return DeepExplanation(msg)
+        if self.is_complex(X) and type(X) is type(Y):
+            return self.compare_complex_stuff(X, Y)
 
-        elif type(X) is not type(Y):  # different types
-            xname, yname = map(lambda _: type(_).__name__, (X, Y))
-            msg = 'X%s is a %%s and Y%s is a %%s instead' % (
-                red(c.current_X_keys),
-                green(c.current_Y_keys),
-            ) % (xname, yname)
-            exp = DeepExplanation(msg)
-
-        else:
-            exp = self.compare_complex_stuff(X, Y)
+        # maintaining backwards compatability between error messages
+        kwargs = {}
+        if self.is_simple(X) and self.is_simple(Y):
+            kwargs['msg_format'] = 'X%%s is %r whereas Y%%s is %r' % (X, Y)
+        elif type(X) is not type(Y):
+            kwargs['msg_format'] = 'X%%s is a %s and Y%%s is a %s instead' % (
+                type(X).__name__, type(Y).__name__)
+        exp = self.compare_generic(X, Y, **kwargs)
 
         if isinstance(exp, DeepExplanation):
-
             original_X, original_Y = c.parent.operands
             raise exp.as_assertion(original_X, original_Y)
 

--- a/sure/core.py
+++ b/sure/core.py
@@ -35,8 +35,8 @@ from sure.compat import safe_repr, OrderedDict
 
 class Anything(object):
     """Represents any possible value."""
-    def __cmp__(self, _):
-        return 0
+    def __eq__(self, _):
+        return True
 
 anything = Anything()
 

--- a/tests/test_assertion_builder.py
+++ b/tests/test_assertion_builder.py
@@ -808,3 +808,8 @@ def test_equals_anything():
 
     val = [1, 2, 3, 4]
     expect(val).to.be.equal([1, anything, 3, anything])
+
+def test_equals_crosstype():
+    class MyFloat(float):
+        pass
+    expect(MyFloat(1.23)).to.be.equal(1.23)


### PR DESCRIPTION
## Pull Request Type

Please specify the type of the pull request you want to submit:

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Only
- [ ] Testing Only
- [x] Backwards incompatible

## Summary

In compare method, values with different types are hardcoded to be unequal:
https://github.com/gabrielfalcao/sure/blob/dfceb6b957b887d1ed5079b2e834ab12dc9bafcf/sure/core.py#L206
This might cause a problem in cases when two distinct types are comparable. For me problem arises when doing expect(scipy.Float64 value).to.be.equal(float literal). Even though scipy datatype is smart enough to be compared to float without an issue, testcase fails because of different datatypes. Testcase in this PR demonstrates simplest example of such problem.

Python's TestCase.assertEquals in this case uses proper comparison:
https://github.com/python/cpython/blob/2410a06c294d9b091f39f09f638c1d83d0ff440e/Lib/unittest/case.py#L799
This is backwards incompatible PR, because some tests that were failing before will pass now (but not other way around). Still, I think it's worth merging for consistency with default TestCase behavior.