### PR TITLE
Fix a trivial typo (missing word “assertions”) in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ sure
 .. image:: https://img.shields.io/badge/pydoc-web-ff69b4.svg
    :target: http://pydoc.net/sure
 
-An idiomatic testing library for python with powerful and flexible created by `Gabriel Falcão <https://github.com/gabrielfalcao>`_.
+An idiomatic testing library for python with powerful and flexible assertions, created by `Gabriel Falcão <https://github.com/gabrielfalcao>`_.
 Sure's developer experience is inspired and modeled after `RSpec Expectations
 <http://rspec.info/documentation/3.5/rspec-expectations/>`_ and
 `should.js <https://github.com/shouldjs/should.js>`_.


### PR DESCRIPTION
## Pull Request Type

Please specify the type of the pull request you want to submit:

- [ ] Bugfix
- [ ] New Feature
- [x] Documentation Only
- [ ] Testing Only
- [ ] ...

## Summary

Add the missing word “assertions” in the first full sentence of `README.rst`