### PR TITLE
Drop PyPI mock dependency; use unittest.mock instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def read_readme():
         return __doc__
 
 
-install_requires = ["mock", "six"]
+install_requires = ["six"]
 tests_require = ["nose"]
 version = read_version()
 

--- a/sure/core.py
+++ b/sure/core.py
@@ -18,10 +18,7 @@ from __future__ import unicode_literals
 
 import os
 
-try:
-    from mock import _CallList
-except ImportError:
-    from mock.mock import _CallList
+from unittest.mock import _CallList
 
 import inspect
 from six import (

--- a/tests/test_assertion_builder.py
+++ b/tests/test_assertion_builder.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import unicode_literals
 import re
-import mock
+from unittest import mock
 from collections import OrderedDict
 
 from datetime import datetime, timedelta

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist = py27, pypy, py34, py35, py36, py37
 commands = nosetests --rednose -vv --with-coverage --cover-package=sure
 deps =
     six
-    mock
     nose
     rednose
     coverage


### PR DESCRIPTION
This is available in the Python standard library from version 3.3; sure advertises support for 3.6 and later in setup.py

## Pull Request Type

Please specify the type of the pull request you want to submit:

- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Only
- [ ] Testing Only
- [ ] ...

## Summary

Since `unittest.mock` is in the Python standard library, the external dependency is unnecessary.

See also https://fedoraproject.org/wiki/Changes/DeprecatePythonMock; furthermore, an effort is underway to retire the `python-mock` package from Fedora Linux in a near-future release.